### PR TITLE
feat: add docker_pull support for forcing image updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Role Variables
 | `docker_service_copy_files` | `{}` | - | Mapping of `src: dest` regular files to copy to the service directory. `src` must be an absolute path; `dest` is relative to the service directory. |
 | `docker_service_templates` | `{}` | - | Mapping of `src: dest` templates to render into the service directory. `src` must be an absolute path; `dest` is relative to the service directory. |
 | `docker_service_templates_vars` | `{}` | - | Variable map made available to each entry under `docker_service_templates` when rendering templates. |
+| `docker_pull` | `false` | - | When set to `true`, forces Docker images to be pulled from the registry and recreates containers to use the updated images. Useful for refreshing images with mutable tags like `:latest`. |
 
 Template Guidance
 -----------------
@@ -61,6 +62,12 @@ Example Playbook
         docker_service_templates_vars:
           backend_host: localhost
           backend_port: 8080
+        docker_pull: "{{ docker_force_pull | default(false) }}"
+```
+
+To force image updates and container recreation, run the playbook with:
+```bash
+ansible-playbook playbook.yml -e docker_force_pull=true
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,10 +13,10 @@ docker_service_user_id: 1000
 docker_service_group_id: 1000
 
 # All directories in the Docker service directory will be created with this mode
-docker_service_dir_mode: '0770'
+docker_service_dir_mode: "0770"
 
 # All files in the Docker service directory will be created with this mode
-docker_service_file_mode: '0660'
+docker_service_file_mode: "0660"
 
 # Variables to pass to the Docker Compose template
 docker_compose_template_vars: {}
@@ -34,3 +34,6 @@ docker_service_copy_files: {}
 # key is the source template, value is the destination file (relative to the service directory)
 docker_service_templates: {}
 docker_service_templates_vars: {}
+
+# Force pull Docker images and recreate containers
+docker_pull: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,12 @@
 - name: Prepare service directory
   ansible.builtin.include_tasks: prepare.yml
 
+- name: Pull Docker images if docker_pull is true
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ docker_services_root_dir }}/{{ docker_service_name }}"
+  when: docker_pull | default(false) | bool
+  register: docker_pull_result
+
 - name: Determine if Docker Compose needs recreation
   ansible.builtin.set_fact:
     docker_compose_should_recreate: >-
@@ -15,6 +21,7 @@
         (docker_compose_template_result is defined and docker_compose_template_result.changed)
         or (docker_service_copy_files_result is defined and docker_service_copy_files_result.changed)
         or (docker_service_templates_result is defined and docker_service_templates_result.changed)
+        or (docker_pull_result is defined and docker_pull_result.changed)
       }}
 
 - name: Run Docker Compose


### PR DESCRIPTION
- Add docker_pull variable to defaults (defaults to false)
- Add task to pull Docker images when docker_pull is true
- Modify recreation logic to include pull results
- Containers are recreated when images are pulled and changed
- Update README.md with docker_pull documentation and usage examples
- Change quote style in defaults for consistency (single to double quotes)
- Maintains backward compatibility with existing playbooks